### PR TITLE
remove ogg link

### DIFF
--- a/podcast.rss
+++ b/podcast.rss
@@ -44,7 +44,6 @@ layout: null
                 <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
                 <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
                 <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-                <enclosure url="{{ post.ogg-url | prepend: site.baseurl | prepend: site.url }}" length="1" type="audio/ogg"/>
                 <enclosure url="{{ post.mp3-url | prepend: site.baseurl | prepend: site.url }}" length="1" type="audio/mp3"/>
                 <itunes:author>{{ site.author }}</itunes:author>
                 <itunes:summary><![CDATA[{{ post.content | strip_html | expand_urls: site.url | cdata_escape }}]]></itunes:summary>


### PR DESCRIPTION
Some OS/RSS readers seem to get confused with multiple urls with audio. Falling back on mp3, since ogg seems to be a too new format for some ;)

close #24